### PR TITLE
Change image to .Net 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime:8.0
+FROM mcr.microsoft.com/dotnet/runtime:9.0
 
 LABEL name=resonite-headless maintainer="jackthefoxotter@gmail.com"
 


### PR DESCRIPTION
Merging as Resonite's headless main branch changed to .Net9 with Version 2024.12.2.1188